### PR TITLE
deployをThread内で実行するように変更

### DIFF
--- a/lib/ruboty/handlers/capistrano.rb
+++ b/lib/ruboty/handlers/capistrano.rb
@@ -10,10 +10,12 @@ module Ruboty
         deployment = Ruboty::Capistrano::Actions::Deployment.new(deploy_params(message))
         message.reply(deployment.message_before_deploy)
 
-        if deployment.run
-          message.reply(deployment.message_after_deploy)
-        else
-          message.reply(deployment.errors.join(','))
+        Thread.start do
+          if deployment.run
+            message.reply(deployment.message_after_deploy)
+          else
+            message.reply(deployment.errors.join(','))
+          end
         end
       end
 


### PR DESCRIPTION
デプロイに時間のかかるサービスだと， `ruboty-slack_rtm` がSlack側に `ping` `pong` をちゃんと返せずに `Disconnected` されてしまい，デプロイ完了通知が来ない = ちゃんとデプロイ出来たのかがわからない。という問題が発生していました。

```
INFO -- : Disconnected
```

これを解決するために，デプロイの部分を Thread化 することで，デプロイ中も `ping` `pong` をちゃんと返せて，Slack側とのコネクションが切れないようにしました。